### PR TITLE
Adjusted docs to reflect deprecation cycle being release-based instead of time based

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The new namespace is: tools.gsf.
 
 Starting the initial release of GSF-12, pre-existing classes will be progressively moved onto the LEGACY artifact.
 
-As per the LEGACY artifact's semantic, this implies "old" classes will enter the deprecation cycle, which ends up in permanent (physical) removal from the GSF's codebase / project in periods of 12 to 24 months.
+As per the LEGACY artifact's semantic, this implies "old" classes will enter the deprecation cycle.
+
+Components that get deprecated will be physically removed from the GSF's codebase / project in the next major release after deprecation occurs.
 
 Therefore, you are strongly advised to start using the new namespace (e.g. packages / classnames). 
 

--- a/gsf-legacy/src/site/apt/index.apt
+++ b/gsf-legacy/src/site/apt/index.apt
@@ -22,6 +22,6 @@ GSF LEGACY Submodule
 	
 	Components will be progressively added to this JAR in future releases, as soon as they get deprecated.
 	
-	Deprecated components will be physically removed from the GSF JAR submodule (and the GSF project's codebase altogether) in periods of 12 to 24 months.
+	Components that get deprecated (and added to the LEGACY jar) will be physically removed from the GSF's codebase / project in the next major release after deprecation occurs.
 	
 	Full backwards-compatibility is not guaranteed for deprecated components. In fact, in some exceptional cases, deprecated components and new features could be incompatible with each other.

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -80,7 +80,9 @@ An Important Note on Backwards-Compatibility
 		
 		* New "CORE" classes will belong to a subpackage of "tools.gsf" (or "tools.gsf" itself) 
 	
-	As per the LEGACY artifact's semantic, the above implies "old" classes will enter the deprecation cycle, which ends up in permanent (physical) removal from the GSF's codebase / project in periods of 12 to 24 months.
+	As per the LEGACY artifact's semantic, the above implies "old" classes will enter the deprecation cycle.
+	
+	Components that get deprecated (and added to the LEGACY jar) will be physically removed from the GSF's codebase / project in the next major release after deprecation occurs.
 	
 	Therefore, you are strongly advised to start using the new namespace (e.g. packages / classnames). 
 


### PR DESCRIPTION
…d of time-based
